### PR TITLE
Fix nextRandom to respect min-max range

### DIFF
--- a/c3-control-flows/e301_bsearch.c
+++ b/c3-control-flows/e301_bsearch.c
@@ -44,8 +44,8 @@ nextRandom(int min,
     return max;
   }
   int ret = max + 1;
-  while (ret > max) {
-    ret = rand() / ( (RAND_MAX + 1U) / max ) + min;
+  while (ret < min || ret > max) {
+    ret = rand() / ((RAND_MAX + 1U) / (max - min + 1)) + min;
   }
   return ret;
 }


### PR DESCRIPTION
## Summary
- adjust `nextRandom` to divide by `max - min + 1` so generated values land within requested range
- guard loop to reroll when number is outside `[min, max]`

## Testing
- `gcc -Wall -Wextra -std=c11 -pedantic c3-control-flows/e301_bsearch.c -o c3-control-flows/e301_bsearch`
- `./c3-control-flows/e301_bsearch > /tmp/out.txt && awk 'BEGIN{min=1e9; max=-1e9} {for(i=1;i<=NF;i++) if($i ~ /^-?[0-9]+$/){if($i>max)max=$i; if($i<min)min=$i}} END{print min, max}' /tmp/out.txt`


------
https://chatgpt.com/codex/tasks/task_e_68a3bd40fa288330ad75e891529164ea