### PR TITLE
Fix typos in ctof tutorial comments

### DIFF
--- a/c1-tutorial/e104_ctof.c
+++ b/c1-tutorial/e104_ctof.c
@@ -1,8 +1,8 @@
 #include <stdio.h>
 
-const double CELSIUS_LOWER = 36.5;      // lower limit of tempr table in cels.
+const double CELSIUS_LOWER = 36.5;      // lower limit of temperature table in cels.
 const double CELSIUS_UPPER = 38.5;      // upper limit
-const double STEP = 0.1;                // #define vesus const vesus enum ?
+const double STEP = 0.1;                // #define versus const versus enum ?
 
 double celsiusToFahrenheit(double celsius) {
   return celsius * 1.8 + 32.0;


### PR DESCRIPTION
## Summary
- fix comment typos in e104_ctof.c

## Testing
- `gcc -std=c11 -Wall -Wextra -pedantic c1-tutorial/e104_ctof.c -o /tmp/e104_ctof`


------
https://chatgpt.com/codex/tasks/task_e_68a3be5a3c6c8330b3ad93134016b975