### PR TITLE
Fix expand sequence comment example

### DIFF
--- a/c3-control-flows/e303_expand.c
+++ b/c3-control-flows/e303_expand.c
@@ -5,7 +5,7 @@
 enum { BUFFER_SIZE = 128 };
 
 /* Makes a sequence from 'front' to 'back'.
-   e.g. front=a, back=g, sequence=abcefg */
+   e.g. front=a, back=g, sequence=abcdefg */
 char *
 sequence(char * dest,
          int    front,


### PR DESCRIPTION
## Summary
- correct example comment in `sequence()` to use `abcdefg`

## Testing
- `gcc -Wall -Wextra -pedantic -std=c99 c3-control-flows/e303_expand.c -o /tmp/e303_expand`


------
https://chatgpt.com/codex/tasks/task_e_68a3bf2f50a88330806ba6f1e1ef2640